### PR TITLE
Add constructor for N-ary sums

### DIFF
--- a/src/Circuit/Builder.hs
+++ b/src/Circuit/Builder.hs
@@ -156,8 +156,14 @@ circMul x y = newOp (OpMul x y)
 circProd :: [Ref] -> Builder Ref
 circProd = foldTreeM circMul
 
+-- This creates a balanced tree of binary additions
+-- Do not change this API as users of this module for oblivious computation
+-- require only binary operators
 circSum :: [Ref] -> Builder Ref
 circSum = foldTreeM circAdd
+
+circSumN :: [Ref] -> Builder Ref
+circSumN = newOp . OpNAdd
 
 circXor :: Ref -> Ref -> Builder Ref
 circXor x y = do


### PR DESCRIPTION
I added a constructor instead of altering the normal `Sum` constructor because I was told that some backends rely on the fact that certain operators are binary.

If there’s anything that seems off or that you’d like me to address please let me know.

Cheers,

Jose